### PR TITLE
Upgrade metastore listener version to 0.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ from amazonlinux:latest
 
 ENV VAULT_VERSION 0.10.3
 ENV RANGER_VERSION 1.1.0
-ENV APIARY_METASTORE_LISTENER_VERSION 0.0.1
+ENV APIARY_METASTORE_LISTENER_VERSION 0.1.0
 
 COPY files/RPM-GPG-KEY-emr /etc/pki/rpm-gpg/RPM-GPG-KEY-emr
 COPY files/emr-apps.repo /etc/yum.repos.d/emr-apps.repo


### PR DESCRIPTION
Tiny PR to upgrade to the latest version of the metastore listener which I released earlier today. If we have this in then we can do a release of this docker package sometime soon and use this on our side to start testing downstream usage of the events generated by the listener.